### PR TITLE
fix(flickingDiagnostics): don't hide diagnostics in insert mode

### DIFF
--- a/lua/nvim/diagnostic_virtual_text_config/init.lua
+++ b/lua/nvim/diagnostic_virtual_text_config/init.lua
@@ -86,7 +86,7 @@ M.setup = function(_setup)
     end,
     hide = function(namespace, bufnr)
       local ns = vim.diagnostic.get_namespace(namespace)
-      if ns.user_data.virt_lines_ns then
+      if ns.user_data.virt_lines_ns and vim.api.nvim_get_mode().mode ~= "i" then
         vim.api.nvim_buf_clear_namespace(
           bufnr,
           ns.user_data.virt_lines_ns,


### PR DESCRIPTION
Problem:
When switching to insert mode using o or O the diagnostics disappear and reappear once or twice, in a kinda flickering manner.
I find this highly disturbing, it makes me lose my focus completely.

Offered Solution:
Simply disable the clear_namespace function (hide) when in insert_mode